### PR TITLE
chore: clear out redundant code and comments that outlived their subject

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -239,14 +239,6 @@
       button.primary:hover {
         filter: brightness(1.08);
       }
-      button[disabled] {
-        opacity: 0.45;
-        cursor: default;
-        pointer-events: none;
-      }
-      button[hidden] {
-        display: none;
-      }
     </style>
   </head>
   <body>

--- a/src-tauri/src/controls.rs
+++ b/src-tauri/src/controls.rs
@@ -95,7 +95,9 @@ pub enum Action {
     UpdateDsh,
     CheckApp,
     Autostart,
-    /// Turn the finished-turn notification on or off; see [`crate::settings`].
+    /// Turn this app's notifications on or off — every one of them, not just
+    /// the finished-turn toast this verb is named after. The gate is in
+    /// `notify::show`, which they all pass through; see [`crate::settings`].
     NotifyTurns,
     Quit,
     /// dsh switched language under a document that is not going to load

--- a/src-tauri/src/controls.rs
+++ b/src-tauri/src/controls.rs
@@ -451,16 +451,79 @@ pub fn relabel(app: &AppHandle) {
     );
 }
 
+/// `function make(tag, className, parent)`, for the injected scripts that build
+/// a card out of elements: the titlebar's siblings in [`crate::dialog`],
+/// [`crate::panel`] and [`crate::setup`].
+///
+/// Five lines, and it was five lines written out three times. Not because
+/// anything about it is subtle, but because three copies of a helper is three
+/// places a fourth card would be tempted to copy it from again.
+pub(crate) fn dom_make() -> &'static str {
+    r#"  function make(tag, className, parent) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (parent) parent.appendChild(node);
+    return node;
+  }"#
+}
+
+/// `function paint(node)`, which puts `dark_class` on `node` for as long as
+/// dsh's page is dark and takes it off again when it is not.
+///
+/// dsh's theme is the *page's*, not the window's: it writes `color-scheme` on
+/// the root element and `data-ds-dark-theme` on the body, and switching it
+/// inside the UI changes both without anything reaching the webview's own
+/// `prefers-color-scheme` — which is settled when the window is built (see
+/// [`crate::theme`]) and has nothing to move it afterwards. So every card this
+/// app draws reads the page, and falls back to the media query only where the
+/// page says nothing either way: the loading page, whose `color-scheme` is the
+/// bare `light dark`.
+///
+/// One function because there is one answer. This was written out four times —
+/// once per card — and each copy carried a comment telling the next reader to
+/// keep it in step with the others by hand. Nothing checked that they were, so
+/// a correction to how dsh's theme is read would have been a correction to one
+/// card and a silent divergence in three. `every_card_reads_the_theme_the_same_way`
+/// now pins that they all come from here.
+pub(crate) fn theme_watcher(dark_class: &str) -> String {
+    format!(
+        r#"  function paint(node) {{
+    var media = window.matchMedia('(prefers-color-scheme:dark)');
+
+    function dark() {{
+      if (document.body.hasAttribute('data-ds-dark-theme')) return true;
+      var declared = getComputedStyle(document.documentElement).colorScheme || '';
+      var light = declared.indexOf('light') !== -1;
+      var night = declared.indexOf('dark') !== -1;
+      return night !== light ? night : media.matches;
+    }}
+
+    function repaint() {{
+      node.classList.toggle({dark_class:?}, dark());
+    }}
+
+    repaint();
+    var watch = new MutationObserver(repaint);
+    watch.observe(document.documentElement, {{
+      attributes: true, attributeFilter: ['style', 'class', 'data-theme']
+    }});
+    watch.observe(document.body, {{
+      attributes: true, attributeFilter: ['style', 'class', 'data-ds-dark-theme']
+    }});
+    media.addEventListener('change', repaint);
+  }}"#
+    )
+}
+
 /// The script that draws all of it, injected into every document the window
 /// loads.
 ///
 /// The dots carry their own colour, the same three macOS uses, so there is
 /// nothing about them that has to follow dsh's theme — they read the same
 /// against a light page and a dark one. The menu does not have that luxury: it
-/// is text on a panel, so it follows the theme of the page it is drawn over,
-/// watching the two things dsh's own theme writes onto the document rather than
-/// the webview's `prefers-color-scheme` — which is settled when the window is
-/// built (see `theme`) and does not move when the theme is switched inside dsh.
+/// is text on a panel, so it follows the theme of the page it is drawn over;
+/// see [`theme_watcher`], which is where that reading lives for every card in
+/// the app.
 pub fn script() -> String {
     let titlebar_height = TITLEBAR_HEIGHT;
     let dot = DOT;
@@ -468,6 +531,7 @@ pub fn script() -> String {
     let pad = ROW_PAD;
 
     let labels = labels();
+    let watcher = theme_watcher("dsh-wc-dark");
 
     format!(
         r#"(function () {{
@@ -540,6 +604,11 @@ pub fn script() -> String {
   function signal(verb) {{
     window.location.href = '{SCHEME}://' + verb;
   }}
+
+  // ----------------------------------------------------------- the theme --
+  // Pasted in from `controls::theme_watcher`, which every card in this app
+  // draws its dark mode from; the rationale is there.
+{watcher}
 
   // ------------------------------------------------------------- links --
   function isExternal(url) {{
@@ -875,40 +944,10 @@ pub fn script() -> String {
       attributeFilter: ['lang']
     }});
 
-    // ----------------------------------------------------------- the theme --
-
-    // dsh's theme is the page's, not the window's: it writes `color-scheme` on
-    // the root element and `data-ds-dark-theme` on the body, and switching it
-    // inside the UI changes both without anything reaching the webview's own
-    // `prefers-color-scheme` -- which is fixed when the window is built and has
-    // nothing to move it afterwards. So the menu reads the page, and falls back
-    // to the media query only where the page says nothing either way: the
-    // loading page, whose `color-scheme` is the bare `light dark`.
-    var media = window.matchMedia('(prefers-color-scheme:dark)');
-
-    function dark() {{
-      if (document.body.hasAttribute('data-ds-dark-theme')) return true;
-      var declared = getComputedStyle(document.documentElement).colorScheme || '';
-      var light = declared.indexOf('light') !== -1;
-      var night = declared.indexOf('dark') !== -1;
-      return night !== light ? night : media.matches;
-    }}
-
-    function repaint() {{
-      bar.classList.toggle('dsh-wc-dark', dark());
-    }}
-
     // Before the bar is in the document, so it is never painted the wrong
-    // colour first.
-    repaint();
-    var watch = new MutationObserver(repaint);
-    watch.observe(document.documentElement, {{
-      attributes: true, attributeFilter: ['style', 'class', 'data-theme']
-    }});
-    watch.observe(document.body, {{
-      attributes: true, attributeFilter: ['style', 'class', 'data-ds-dark-theme']
-    }});
-    media.addEventListener('change', repaint);
+    // colour first. `paint` starts watching as well as painting; see
+    // `controls::theme_watcher`.
+    paint(bar);
 
     document.body.appendChild(drag);
     document.body.appendChild(bar);
@@ -1130,6 +1169,54 @@ mod tests {
             action(&Url::parse("dsh-window://close").unwrap()),
             Some(Action::Close)
         ));
+    }
+
+    /// Every card this app draws over dsh's page reads dsh's theme from
+    /// [`theme_watcher`], and none of them from a copy of it.
+    ///
+    /// Written across the four modules on purpose, the way
+    /// `turn::never_reads_this_app_s_own_buttons` is. This was four
+    /// hand-maintained copies of the same twenty lines, each with a comment
+    /// asking the next reader to keep it in step with the others; nothing
+    /// checked that anyone had. A correction to how dsh's theme is read would
+    /// have landed in one card and quietly missed three — the titlebar
+    /// following a theme switch while the dialog over it stayed light.
+    ///
+    /// The assertion is deliberately the whole generated block rather than a
+    /// phrase out of it: a copy that drifts by one line is exactly the failure
+    /// this is here to catch, and matching on a fragment would let it through.
+    #[test]
+    fn every_card_reads_the_theme_the_same_way() {
+        for (what, script, class) in [
+            ("the titlebar", script(), "dsh-wc-dark"),
+            ("a dialog", crate::dialog::script(), "dsh-ask-dark"),
+            ("the plugin panel", crate::panel::script(), "dsh-pp-dark"),
+            ("the runtime chooser", crate::setup::script(), "dsh-su-dark"),
+        ] {
+            assert!(
+                script.contains(&theme_watcher(class)),
+                "{what} must paint itself from `theme_watcher`, not a copy of it"
+            );
+        }
+    }
+
+    /// The three cards built out of elements share one `make`, for the same
+    /// reason: three copies is three places a fourth card copies from.
+    ///
+    /// The titlebar is not in the list. It builds its row by hand and has no
+    /// `make` to share — if it ever grows one, it belongs here too.
+    #[test]
+    fn the_cards_share_one_element_helper() {
+        for (what, script) in [
+            ("a dialog", crate::dialog::script()),
+            ("the plugin panel", crate::panel::script()),
+            ("the runtime chooser", crate::setup::script()),
+        ] {
+            assert!(
+                script.contains(dom_make()),
+                "{what} must build elements with `dom_make`, not a copy of it"
+            );
+        }
     }
 }
 

--- a/src-tauri/src/dialog.rs
+++ b/src-tauri/src/dialog.rs
@@ -491,6 +491,8 @@ pub fn script() -> String {
     let scheme = crate::controls::SCHEME;
     let font = crate::controls::FONT;
     let dismissed = DISMISSED;
+    let maker = crate::controls::dom_make();
+    let watcher = crate::controls::theme_watcher("dsh-ask-dark");
 
     format!(
         r#"(function () {{
@@ -530,40 +532,9 @@ pub fn script() -> String {
     return row.querySelectorAll('button');
   }}
 
-  function make(tag, className, parent) {{
-    var node = document.createElement(tag);
-    if (className) node.className = className;
-    if (parent) parent.appendChild(node);
-    return node;
-  }}
+{maker}
 
-  // dsh's theme is the page's, not the window's. Read exactly the way the
-  // titlebar and the plugin panel read it; see controls.rs.
-  function paint(node) {{
-    var media = window.matchMedia('(prefers-color-scheme:dark)');
-
-    function dark() {{
-      if (document.body.hasAttribute('data-ds-dark-theme')) return true;
-      var declared = getComputedStyle(document.documentElement).colorScheme || '';
-      var light = declared.indexOf('light') !== -1;
-      var night = declared.indexOf('dark') !== -1;
-      return night !== light ? night : media.matches;
-    }}
-
-    function repaint() {{
-      node.classList.toggle('dsh-ask-dark', dark());
-    }}
-
-    repaint();
-    var watch = new MutationObserver(repaint);
-    watch.observe(document.documentElement, {{
-      attributes: true, attributeFilter: ['style', 'class', 'data-theme']
-    }});
-    watch.observe(document.body, {{
-      attributes: true, attributeFilter: ['style', 'class', 'data-ds-dark-theme']
-    }});
-    media.addEventListener('change', repaint);
-  }}
+{watcher}
 
   function build() {{
     var style = document.createElement('style');

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -100,36 +100,14 @@ fn dsh_locale() -> Option<String> {
 
 /// Read `locale.preference` out of the settings document.
 ///
-/// The same scan [`crate::theme`] reads `ui-theme.preference` with, for the
-/// same reason: every namespace is a top-level key with its section indented
-/// under it, and one string out of a file whose other sections belong to
-/// plugins is not worth pulling in a YAML parser for. Anything the scan does
-/// not recognise leaves the answer `None`, which is the system locale — what
-/// this did before there was a preference to read.
+/// The same scan [`crate::theme`] reads `ui-theme.preference` with, and now
+/// literally the same one — see [`crate::theme::field`]. A key that is present
+/// but empty is nothing said, which leaves the answer `None`: the system
+/// locale, what this did before there was a preference to read.
 fn parse(text: &str) -> Option<String> {
-    let mut section = false;
-
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-
-        if !line.starts_with([' ', '\t']) {
-            section = trimmed == "locale:";
-            continue;
-        }
-        if !section {
-            continue;
-        }
-
-        if let Some(value) = trimmed.strip_prefix("preference:") {
-            let value = value.trim().trim_matches(['"', '\'']);
-            return (!value.is_empty()).then(|| value.to_string());
-        }
-    }
-
-    None
+    crate::theme::field(text, "locale", "preference")
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 /// One string in both languages, Chinese first.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1122,22 +1122,26 @@ fn show_plugins(app: &tauri::AppHandle, session: &Session, first: bool) {
     session.splash.plugins(&window, &plugins::listing(app), first);
 }
 
-/// Install what the panel asked for, with `dsh web` down for the duration.
+/// Run one pnpm job against the profile with `dsh web` down for the duration,
+/// reporting onto the panel.
 ///
-/// It has to come down: pnpm is about to rewrite the profile directory the
-/// running server read its plugins out of. It also has to come back up
-/// afterwards, which is what leaving the panel does — the new plugins are only
-/// in the window once dsh has been started again to load them.
-fn install_plugins(app: &tauri::AppHandle, ids: Vec<String>, spec: Option<String>) {
+/// The server has to come down: pnpm is about to rewrite the profile directory
+/// the running server read its plugins out of. It also has to come back up
+/// afterwards, which is what leaving the panel does — a change to the profile
+/// is only in the window once dsh has been started again to load it.
+///
+/// Installing and removing were two copies of this, differing in three strings
+/// and the one line that does the work. The copies are the reason it is worth
+/// naming what they shared: the [`BUSY`] claim has to be taken on this thread
+/// and released by the [`Busy`] guard on the spawned one, and a second job
+/// slipping between those two would be a pnpm rewriting the directory the
+/// first one is reading.
+fn change_plugins<F>(app: &tauri::AppHandle, busy: &str, done: &'static str, work: F)
+where
+    F: FnOnce(&tauri::AppHandle, &plugins::Log<'_>) -> Result<(), String> + Send + 'static,
+{
     if BUSY.swap(true, Ordering::SeqCst) {
-        dsh::note(
-            app,
-            t!("请稍等", "One moment"),
-            t!(
-                "dsh 正在启动或更新中，等它忙完再装插件。",
-                "dsh is starting or updating; wait for that to finish before installing plugins."
-            ),
-        );
+        dsh::note(app, t!("请稍等", "One moment"), busy);
         return;
     }
 
@@ -1153,66 +1157,47 @@ fn install_plugins(app: &tauri::AppHandle, ids: Vec<String>, spec: Option<String
         stop_server(&session);
 
         let log = |line: &str| session.splash.plugin_log(&window, line);
-        match plugins::install(&app, &ids, spec.as_deref(), &log) {
+        match work(&app, &log) {
             Ok(()) => {
                 session.splash.plugin_lists(&window, &plugins::listing(&app));
-                session.splash.plugin_done(
-                    &window,
-                    true,
-                    t!(
-                        "装好了。回到 dsh 时会重新启动它，插件在那之后生效。",
-                        "Done. dsh restarts on the way back, and the plugins take effect then."
-                    ),
-                );
+                session.splash.plugin_done(&window, true, done);
             }
             Err(error) => session.splash.plugin_done(&window, false, &error),
         }
     });
 }
 
-/// Take the ticked plugins out again, with `dsh web` down for the duration and
-/// for the same reason the install takes it down: pnpm is about to rewrite the
-/// directory the running server read them out of.
+/// Install what the panel asked for: the ticked presets, and whatever was
+/// typed into its box.
+fn install_plugins(app: &tauri::AppHandle, ids: Vec<String>, spec: Option<String>) {
+    change_plugins(
+        app,
+        t!(
+            "dsh 正在启动或更新中，等它忙完再装插件。",
+            "dsh is starting or updating; wait for that to finish before installing plugins."
+        ),
+        t!(
+            "装好了。回到 dsh 时会重新启动它，插件在那之后生效。",
+            "Done. dsh restarts on the way back, and the plugins take effect then."
+        ),
+        move |app, log| plugins::install(app, &ids, spec.as_deref(), log),
+    );
+}
+
+/// Take the ticked plugins out again.
 fn remove_plugins(app: &tauri::AppHandle, names: Vec<String>) {
-    if BUSY.swap(true, Ordering::SeqCst) {
-        dsh::note(
-            app,
-            t!("请稍等", "One moment"),
-            t!(
-                "dsh 正在启动或更新中，等它忙完再动插件。",
-                "dsh is starting or updating; wait for that to finish before changing plugins."
-            ),
-        );
-        return;
-    }
-
-    let session = app.state::<Session>().inner().clone();
-    let app = app.clone();
-
-    std::thread::spawn(move || {
-        let _busy = Busy;
-        let Some(window) = app.get_webview_window("main") else {
-            return;
-        };
-
-        stop_server(&session);
-
-        let log = |line: &str| session.splash.plugin_log(&window, line);
-        match plugins::remove(&app, &names, &log) {
-            Ok(()) => {
-                session.splash.plugin_lists(&window, &plugins::listing(&app));
-                session.splash.plugin_done(
-                    &window,
-                    true,
-                    t!(
-                        "卸载完成。回到 dsh 时会重新启动它。",
-                        "Removed. dsh restarts on the way back."
-                    ),
-                );
-            }
-            Err(error) => session.splash.plugin_done(&window, false, &error),
-        }
-    });
+    change_plugins(
+        app,
+        t!(
+            "dsh 正在启动或更新中，等它忙完再动插件。",
+            "dsh is starting or updating; wait for that to finish before changing plugins."
+        ),
+        t!(
+            "卸载完成。回到 dsh 时会重新启动它。",
+            "Removed. dsh restarts on the way back."
+        ),
+        move |app, log| plugins::remove(app, &names, log),
+    );
 }
 
 /// Leave the panel: back to dsh, starting it if it is not running.

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -23,6 +23,8 @@
 pub fn script() -> String {
     let scheme = crate::controls::SCHEME;
     let font = crate::controls::FONT;
+    let maker = crate::controls::dom_make();
+    let watcher = crate::controls::theme_watcher("dsh-pp-dark");
 
     // One object rather than a literal per string: they are pasted into
     // JavaScript, and a label is one apostrophe away from being a syntax error
@@ -97,12 +99,7 @@ pub fn script() -> String {
     window.location.href = '{scheme}://' + verb;
   }}
 
-  function make(tag, className, parent) {{
-    var node = document.createElement(tag);
-    if (className) node.className = className;
-    if (parent) parent.appendChild(node);
-    return node;
-  }}
+{maker}
 
   function button(parent, text, onclick) {{
     var node = make('button', '', parent);
@@ -309,34 +306,7 @@ pub fn script() -> String {
     signal('plugins-remove?names=' + encodeURIComponent(names.join(',')));
   }}
 
-  // dsh's theme is the page's, not the window's, and the panel is drawn over
-  // the page. Read exactly the way the titlebar reads it -- see controls.rs,
-  // which explains why the media query is only the fallback.
-  function paint(card) {{
-    var media = window.matchMedia('(prefers-color-scheme:dark)');
-
-    function dark() {{
-      if (document.body.hasAttribute('data-ds-dark-theme')) return true;
-      var declared = getComputedStyle(document.documentElement).colorScheme || '';
-      var light = declared.indexOf('light') !== -1;
-      var night = declared.indexOf('dark') !== -1;
-      return night !== light ? night : media.matches;
-    }}
-
-    function repaint() {{
-      card.classList.toggle('dsh-pp-dark', dark());
-    }}
-
-    repaint();
-    var watch = new MutationObserver(repaint);
-    watch.observe(document.documentElement, {{
-      attributes: true, attributeFilter: ['style', 'class', 'data-theme']
-    }});
-    watch.observe(document.body, {{
-      attributes: true, attributeFilter: ['style', 'class', 'data-ds-dark-theme']
-    }});
-    media.addEventListener('change', repaint);
-  }}
+{watcher}
 
   function build() {{
     var style = document.createElement('style');

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -137,7 +137,7 @@ pub fn script() -> String {
   }}
 
   function row(preset) {{
-    var line = make('label', 'dsh-pp-row dsh-pp-card-row');
+    var line = make('label', 'dsh-pp-row');
 
     var box = make('input', '', line);
     box.type = 'checkbox';
@@ -188,7 +188,7 @@ pub fn script() -> String {
 
   /** One plugin that is already in the profile, and so can be taken out. */
   function holding(item) {{
-    var line = make('label', 'dsh-pp-row dsh-pp-card-row');
+    var line = make('label', 'dsh-pp-row');
 
     var box = make('input', '', line);
     box.type = 'checkbox';

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -789,7 +789,18 @@ fn spec_name(spec: &str) -> Option<String> {
     if spec.is_empty() || spec.contains(['/', '\\', ':']) && !spec.starts_with('@') {
         return None;
     }
-    // A scoped name keeps its leading `@`; the range separator is a later one.
+    without_range(spec)
+}
+
+/// A `name@version` with the version range cut off, or `None` when what is
+/// left is not usable as a name.
+///
+/// A scoped name keeps its leading `@`, so the separator is the *last* one and
+/// only when something precedes it. Shared by [`spec_name`] and
+/// [`pnpm_blamed`]: one reads a spec the user typed and the other a spec pnpm
+/// printed, but `@scope/pkg@1.2.3` has to come apart the same way in both, and
+/// it came apart in two places here before it came apart in one.
+fn without_range(spec: &str) -> Option<String> {
     let name = match spec.rfind('@') {
         Some(at) if at > 0 => &spec[..at],
         _ => spec,
@@ -1079,15 +1090,7 @@ fn pnpm_blamed(line: &str) -> Option<String> {
         return None;
     }
 
-    // A scoped name keeps its leading `@`, so the version separator is the
-    // *last* `@`, and only when something follows the first character.
-    let name = match spec.rfind('@') {
-        Some(at) if at > 0 => &spec[..at],
-        _ => spec,
-    };
-
-    let name = name.trim();
-    (!name.is_empty() && !name.contains(' ')).then(|| name.to_string())
+    without_range(spec)
 }
 
 /// Whether this line is pnpm failing to delete or replace a path.

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -260,11 +260,12 @@ fn command(app: &tauri::AppHandle, port: Option<u16>) -> Command {
     // `--port 0` is dsh's own way of saying "any free one"; a number is the one
     // a reconnect is trying to land back on.
     let port = port.map_or_else(|| "0".to_string(), |port| port.to_string());
-    command.args(["web", "--no-open", "--port", &port]);
     // `--no-open` keeps dsh from handing the URL to the system's default
     // browser: this app's own window navigates to it, so a second tab in the
     // user's browser is a leftover from running `dsh web` in a terminal, not
     // something the desktop client wants. Newer dsh defaults to opening it.
+    command.args(["web", "--no-open", "--port", &port]);
+
     // dsh shells out to `node` for workers and plugin tooling, and the shim
     // itself needs one. See `dsh::apply_path`.
     crate::dsh::apply_path(app, &mut command);

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -134,7 +134,9 @@ mod tests {
     use serde_json::{json, Map, Value};
 
     /// The read half of `read`, without the `AppHandle` a test cannot build.
-    /// Kept in step with it by `parses_like_the_reader`, below.
+    /// A copy of it, and nothing pins the two together: a change to how the
+    /// reader treats a document has to be made here as well or these tests go
+    /// on passing against the old behaviour.
     fn parse(text: &str) -> Map<String, Value> {
         match serde_json::from_str::<Value>(text) {
             Ok(Value::Object(map)) => map,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -49,12 +49,12 @@ use tauri::AppHandle;
 /// name that promised only the finished-turn toast was describing a narrower
 /// switch than the one actually wired up. The menu item says the same thing:
 /// "Notifications", not "Notify when a turn finishes".
+///
+/// The old name is not read as a fallback. Both the switch and the rename
+/// landed before v0.1.7, so no released build ever wrote `notifyOnTurnEnd` and
+/// there is no file in the wild holding one — the fallback only ever covered a
+/// dev build of the branch it was written on.
 const NOTIFY_KEY: &str = "notifications";
-
-/// What the key was called while this was a turn-only switch, still read so a
-/// preference set by an earlier build of this branch is not silently reset. Only
-/// ever read; a write always uses [`NOTIFY_KEY`].
-const NOTIFY_KEY_WAS: &str = "notifyOnTurnEnd";
 
 const NOTIFY_DEFAULT: bool = true;
 
@@ -63,7 +63,6 @@ pub fn notifications(app: &AppHandle) -> bool {
     let document = read(app);
     document
         .get(NOTIFY_KEY)
-        .or_else(|| document.get(NOTIFY_KEY_WAS))
         .and_then(Value::as_bool)
         .unwrap_or(NOTIFY_DEFAULT)
 }
@@ -148,7 +147,6 @@ mod tests {
         let document = parse(text);
         document
             .get(super::NOTIFY_KEY)
-            .or_else(|| document.get(super::NOTIFY_KEY_WAS))
             .and_then(Value::as_bool)
             .unwrap_or(super::NOTIFY_DEFAULT)
     }
@@ -159,25 +157,11 @@ mod tests {
         assert!(notify(r#"{"notifications": true}"#));
     }
 
-    /// The key this was called while it was a turn-only switch still reads, so
-    /// someone who turned notifications off on an earlier build of this branch
-    /// does not find them back on.
+    /// The name this switch had before v0.1.7 is not a fallback: it reads as
+    /// any other key this build does not know, which is to say the default.
     #[test]
-    fn still_reads_the_old_key() {
-        assert!(!notify(r#"{"notifyOnTurnEnd": false}"#));
-        assert!(notify(r#"{"notifyOnTurnEnd": true}"#));
-    }
-
-    /// With both present the current name wins: it is the only one ever
-    /// written, so it is the one that was set most recently.
-    #[test]
-    fn the_current_key_beats_the_old_one() {
-        assert!(notify(
-            r#"{"notifications": true, "notifyOnTurnEnd": false}"#
-        ));
-        assert!(!notify(
-            r#"{"notifications": false, "notifyOnTurnEnd": true}"#
-        ));
+    fn the_name_it_had_first_is_just_an_unknown_key() {
+        assert!(notify(r#"{"notifyOnTurnEnd": false}"#));
     }
 
     /// Every way the file can be unusable ends at the default, because a

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -845,6 +845,8 @@ pub fn answered(choice: Choice) {
 pub fn script() -> String {
     let scheme = crate::controls::SCHEME;
     let font = crate::controls::FONT;
+    let maker = crate::controls::dom_make();
+    let watcher = crate::controls::theme_watcher("dsh-su-dark");
 
     let labels = json!({
         "title": t!("选择运行环境", "Choose a runtime"),
@@ -940,12 +942,7 @@ pub fn script() -> String {
     window.location.href = '{scheme}://' + verb;
   }}
 
-  function make(tag, className, parent) {{
-    var node = document.createElement(tag);
-    if (className) node.className = className;
-    if (parent) parent.appendChild(node);
-    return node;
-  }}
+{maker}
 
   function button(parent, text, onclick, primary) {{
     var node = make('button', primary ? 'dsh-su-primary' : '', parent);
@@ -1063,32 +1060,7 @@ pub fn script() -> String {
     return line;
   }}
 
-  // dsh's theme is the page's, read the way the titlebar and the panels read it.
-  function paint(node) {{
-    var media = window.matchMedia('(prefers-color-scheme:dark)');
-
-    function dark() {{
-      if (document.body.hasAttribute('data-ds-dark-theme')) return true;
-      var declared = getComputedStyle(document.documentElement).colorScheme || '';
-      var light = declared.indexOf('light') !== -1;
-      var night = declared.indexOf('dark') !== -1;
-      return night !== light ? night : media.matches;
-    }}
-
-    function repaint() {{
-      node.classList.toggle('dsh-su-dark', dark());
-    }}
-
-    repaint();
-    var watch = new MutationObserver(repaint);
-    watch.observe(document.documentElement, {{
-      attributes: true, attributeFilter: ['style', 'class', 'data-theme']
-    }});
-    watch.observe(document.body, {{
-      attributes: true, attributeFilter: ['style', 'class', 'data-ds-dark-theme']
-    }});
-    media.addEventListener('change', repaint);
-  }}
+{watcher}
 
   function build() {{
     var style = document.createElement('style');

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -653,95 +653,76 @@ fn confirm(app: &AppHandle, choice: &Choice, nodes: &[NodeInfo]) -> bool {
 }
 
 fn act(app: &AppHandle, choice: Choice, nodes: &[NodeInfo], report: &Report) -> Outcome {
-    let result = match choice {
-        Choice::Use(index) => {
-            let Some(node) = nodes.get(index) else {
-                return Outcome::Failed(t!("找不到所选的 Node。", "The chosen Node is gone.").into());
-            };
-            report(t!("正在切换到所选的 Node…", "Switching to the chosen Node…"), -1.0);
-            crate::dsh::run(
-                app,
-                &[
-                    OsStr::new("-Mode"),
-                    OsStr::new("switch"),
-                    OsStr::new("-NodeExe"),
-                    node.path.as_os_str(),
-                ],
-                report,
-            )
-        }
-        Choice::InstallDsh(index) => {
-            let Some(node) = nodes.get(index) else {
-                return Outcome::Failed(t!("找不到所选的 Node。", "The chosen Node is gone.").into());
-            };
-            // Said here rather than left to the script's first `::status`.
-            // Between the confirm dialog closing and that line there is a
-            // PowerShell to start, a 1500-line script to parse and an
-            // `npm prefix -g` to run for the Node's global directory — seconds
-            // in which the card has greyed itself out and said nothing about
-            // why. Every other action below announces itself the same way.
-            report(t!("正在准备安装 dsh…", "Getting ready to install dsh…"), -1.0);
-            crate::dsh::run(
-                app,
-                &[
-                    OsStr::new("-Mode"),
-                    OsStr::new("install-dsh"),
-                    OsStr::new("-NodeExe"),
-                    node.path.as_os_str(),
-                ],
-                report,
-            )
-        }
-        Choice::InstallNode => {
-            // Same gap as `InstallDsh` above: the script's own first line comes
-            // after the mirror speed test has been set up.
-            report(t!("正在准备安装 Node…", "Getting ready to install Node…"), -1.0);
-            crate::dsh::run(app, &[OsStr::new("-Mode"), OsStr::new("install-node")], report)
-        }
-        Choice::UninstallDsh(index) => {
-            let Some(node) = nodes.get(index) else {
-                return Outcome::Failed(t!("找不到所选的 Node。", "The chosen Node is gone.").into());
-            };
-            report(t!("正在卸载 dsh…", "Uninstalling dsh…"), -1.0);
-            crate::dsh::run(
-                app,
-                &[
-                    OsStr::new("-Mode"),
-                    OsStr::new("uninstall-dsh"),
-                    OsStr::new("-NodeExe"),
-                    node.path.as_os_str(),
-                ],
-                report,
-            )
-        }
-        Choice::DeleteNode(index) => {
-            let Some(node) = nodes.get(index) else {
-                return Outcome::Failed(t!("找不到所选的 Node。", "The chosen Node is gone.").into());
-            };
-            report(t!("正在删除这个 Node…", "Deleting that Node…"), -1.0);
-            crate::dsh::run(
-                app,
-                &[
-                    OsStr::new("-Mode"),
-                    OsStr::new("delete-node"),
-                    OsStr::new("-NodeExe"),
-                    node.path.as_os_str(),
-                ],
-                report,
-            )
-        }
-        Choice::RemoveNode => {
-            report(
-                t!("正在删除应用安装的 Node…", "Deleting the app's Node…"),
-                -1.0,
-            );
-            crate::dsh::run(app, &[OsStr::new("-Mode"), OsStr::new("remove-node")], report)
-        }
+    // Every action is a script mode, a line to say while it runs, and — for the
+    // four that work on one Node in the list — which Node. The modes stay
+    // written as `OsStr::new("…")` literals here because
+    // `every_mode_this_module_runs_is_one_the_scripts_take` reads this file
+    // looking for them.
+    let (mode, saying, index) = match choice {
+        Choice::Use(index) => (
+            OsStr::new("switch"),
+            t!("正在切换到所选的 Node…", "Switching to the chosen Node…"),
+            Some(index),
+        ),
+        Choice::InstallDsh(index) => (
+            OsStr::new("install-dsh"),
+            t!("正在准备安装 dsh…", "Getting ready to install dsh…"),
+            Some(index),
+        ),
+        Choice::UninstallDsh(index) => (
+            OsStr::new("uninstall-dsh"),
+            t!("正在卸载 dsh…", "Uninstalling dsh…"),
+            Some(index),
+        ),
+        Choice::DeleteNode(index) => (
+            OsStr::new("delete-node"),
+            t!("正在删除这个 Node…", "Deleting that Node…"),
+            Some(index),
+        ),
+        Choice::InstallNode => (
+            OsStr::new("install-node"),
+            t!("正在准备安装 Node…", "Getting ready to install Node…"),
+            None,
+        ),
+        Choice::RemoveNode => (
+            OsStr::new("remove-node"),
+            t!("正在删除应用安装的 Node…", "Deleting the app's Node…"),
+            None,
+        ),
         // All handled in [`show`] before the action runs.
         Choice::Quit | Choice::Close | Choice::Rescan => return Outcome::Aborted,
     };
 
-    match result {
+    // Resolved before anything is said, the way it was when each arm did this
+    // for itself: an index that no longer names a Node is a list that moved
+    // under the click, and there is nothing to announce or run.
+    let node = match index {
+        Some(index) => match nodes.get(index) {
+            Some(node) => Some(node),
+            None => {
+                return Outcome::Failed(
+                    t!("找不到所选的 Node。", "The chosen Node is gone.").into(),
+                )
+            }
+        },
+        None => None,
+    };
+
+    // Said here rather than left to the script's first `::status`. Between the
+    // confirm dialog closing and that line there is a PowerShell to start and a
+    // 1500-line script to parse, and then more: `install-dsh` runs an
+    // `npm prefix -g` for the Node's global directory, and `install-node` sets
+    // up the mirror speed test. Seconds in which the card has greyed itself out
+    // and said nothing about why.
+    report(saying, -1.0);
+
+    let mut args = vec![OsStr::new("-Mode"), mode];
+    if let Some(node) = node {
+        args.push(OsStr::new("-NodeExe"));
+        args.push(node.path.as_os_str());
+    }
+
+    match crate::dsh::run(app, &args, report) {
         Ok(true) => Outcome::Done,
         Ok(false) => Outcome::Aborted,
         Err(message) => Outcome::Failed(message),

--- a/src-tauri/src/theme.rs
+++ b/src-tauri/src/theme.rs
@@ -59,8 +59,11 @@ pub fn preference() -> Preference {
     read().unwrap_or_default()
 }
 
-/// `None` when the file could not be read at all, which the poll below tells
-/// apart from a file that simply says nothing about the theme.
+/// `None` when the file could not be read at all, which is a different thing
+/// from a file that is readable and says nothing about the theme — that one
+/// answers `Some(default)`. [`preference`] collapses the two, since the default
+/// is the answer either way; the distinction is kept here because this is where
+/// it is still knowable.
 fn read() -> Option<Preference> {
     let text = std::fs::read_to_string(settings_file()?).ok()?;
     Some(parse(&text).unwrap_or_default())

--- a/src-tauri/src/theme.rs
+++ b/src-tauri/src/theme.rs
@@ -111,14 +111,26 @@ pub fn settings_file() -> Option<PathBuf> {
     Some(home.join("settings.yaml"))
 }
 
-/// Read `ui-theme.preference` out of the settings document.
+/// One indented field out of one top-level section of the settings document,
+/// unquoted and trimmed. `None` when the section is absent or holds no such
+/// field; `Some("")` when it holds the field with nothing after the colon,
+/// which is a distinction both callers care about.
 ///
-/// Every namespace is a top-level key with its section indented under it, so
-/// the field is the one `preference:` inside the block that starts at column
-/// zero with `ui-theme:` — which is little enough of YAML to be worth reading
-/// directly rather than pulling in a parser for one string.
-fn parse(text: &str) -> Option<Preference> {
-    let mut section = false;
+/// Every namespace in the file is a top-level key with its section indented
+/// under it, so the field wanted is the first `<name>:` inside the block that
+/// starts at column zero with `<section>:`. That is little enough of YAML to
+/// read directly rather than pull in a parser for one string — and the rest of
+/// the file belongs to dsh's plugins, which this has no business parsing.
+///
+/// Public to the crate because two things are read this way: the theme below
+/// and the language in [`crate::i18n`]. It was written out once per caller,
+/// which put the one tricky part — that a `preference:` only counts inside the
+/// right section, and `ui-theme` and `locale` both have one — in two places at
+/// once.
+pub(crate) fn field<'a>(text: &'a str, section: &str, name: &str) -> Option<&'a str> {
+    let heading = format!("{section}:");
+    let key = format!("{name}:");
+    let mut inside = false;
 
     for line in text.lines() {
         let trimmed = line.trim();
@@ -127,24 +139,31 @@ fn parse(text: &str) -> Option<Preference> {
         }
 
         if !line.starts_with([' ', '\t']) {
-            section = trimmed == "ui-theme:";
+            inside = trimmed == heading;
             continue;
         }
-        if !section {
+        if !inside {
             continue;
         }
 
-        if let Some(value) = trimmed.strip_prefix("preference:") {
-            return match value.trim().trim_matches(['"', '\'']) {
-                "light" => Some(Preference::Light),
-                "dark" => Some(Preference::Dark),
-                "system" => Some(Preference::System),
-                _ => None,
-            };
+        if let Some(value) = trimmed.strip_prefix(&key) {
+            return Some(value.trim().trim_matches(['"', '\'']));
         }
     }
 
     None
+}
+
+/// Read `ui-theme.preference` out of the settings document. Anything the file
+/// says that is not one of the three known values is `None`, the same as
+/// saying nothing.
+fn parse(text: &str) -> Option<Preference> {
+    match field(text, "ui-theme", "preference")? {
+        "light" => Some(Preference::Light),
+        "dark" => Some(Preference::Dark),
+        "system" => Some(Preference::System),
+        _ => None,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
清理一轮冗余代码和过期注释。行为无变化，除了两处刻意的删减（见下）。

`main..HEAD` 净 **−50 行**（331 增 / 381 删）。

## 起因

`cargo check` 和 `cargo clippy --all-targets` 本来就是零警告，shell / PowerShell 脚本没有未被引用的函数或全局变量，NSIS 钩子没有死宏，注入脚本的 CSS 自定义属性全部有人读，rustdoc 的 intra-doc 链接全部能解析。所以这里全是需要跨文件比对才能发现的东西。

## 过期注释（3cc6a7b）

四处注释描述的代码已经不在了，或者从来没有过：

- **`Action::NotifyTurns`** 还说自己只管 finished-turn 通知。这在 1a2874d 加这个开关时是真的，b89298c 把它扩成"这个 app raise 的每一条通知"之后就不真了——改名改到了菜单标签、`settings`、`notify::show` 和 `toggle_notify_turns`，唯独漏了最初那条 doc comment。结果树里四个地方说一件事，它说另一件。
- **`theme::read`** 说"下面的 poll"会把读不到的文件和没写主题的文件区分开。没有 poll：主题只在启动时读一次，而且这两种情况在 `preference` 里本来就会合成同一个答案。
- **`settings`** 的测试助手说 `parses_like_the_reader` 把它和 reader 钉在一起。没有这个测试，也没有别的东西钉它。
- **`server::command`** 里 `--no-open` 的说明被 8818e19 插在了 `apply_path` 注释的上方，两段无关的注释焊成一段,读起来像 node 和 PATH 是"为什么要抑制浏览器接管"的一部分。

顺带删掉 `dsh-pp-card-row`：7ab66d7 给插件面板两个 row builder 都加了它，但从来没给过它 CSS 规则。

## 重复代码

- **ebab8b4** 主题 watcher 原本被写了四遍（titlebar / dialog / 插件面板 / 运行环境选择器），每份二十行逐字节相同，每份还带一条注释请求下一个读者手动保持同步——而没有任何东西检查过有没有人这么做。现在从 `controls::theme_watcher` 出来一次，`dom_make` 同样处理那个被抄了三遍的五行 `make`。新增 `every_card_reads_the_theme_the_same_way` 和 `the_cards_share_one_element_helper` 钉住四处，写法照 `turn::never_reads_this_app_s_own_buttons` 的先例。
- **5534d34** `spec_name` 和 `pnpm_blamed` 各自以同样的八行结尾（取最后一个 `@`、trim、拒绝空的或带空格的）。现在共用 `without_range`。`spec_name` 自己的 github/tarball/path 守卫留在共用部分之前——`pnpm_blamed` 从来没有这个守卫，也不能有。
- **d3a057e** `i18n::parse` 和 `theme::parse` 是同一个 YAML 段落扫描两遍。值得放到一处的正是最容易写错的那部分：`ui-theme` 和 `locale` **都**有一个叫 `preference` 的 key，所以"这一行只在正确的段落里才算"这个判断原本存在两份，任何一份漂移都会读到另一个段落的值。
- **ecb39fe** `install_plugins` / `remove_plugins` 各四十行、且是同样的四十行，只差三个字符串和一次调用。合并的理由不只是行数：BUSY 的占用发生在调用线程、由 `Busy` guard 在 spawn 出的线程上释放，一个第二个任务从这两者之间挤进来就是一个 pnpm 在改另一个正在读的目录。
- **caa7ec5** `act` 六个分支里有四个是同一个分支。`"找不到所选的 Node。"` 原本被写了四遍，现在一遍。

## 两处刻意的删减

这两个不是纯重构，需要单独看：

- **091ae5c** 停止把 `notifyOnTurnEnd` 当 fallback 读。`git tag --contains` 显示加开关的 1a2874d 和改名的 b89298c **都在 v0.1.7 里**，所以没有任何发布版本写过这个 key——这个 fallback 一直在覆盖一个不存在的情况。
- **c2c74c2** 删掉 loading page 的 `button[disabled]` 和 `button[hidden]`。这页只有两个 button，都不会被 disable 或 hide。`button[hidden]` **有**防御性理由（`all: unset` 会抹掉 `[hidden]` 的 UA `display:none`），但那是为假设保留的规则，而这页经过几轮错误态改动都没用上它。如果觉得该当护栏留着，revert 这个 commit 就行。

## 验证

| | |
|---|---|
| `cargo clippy --all-targets` | 零警告 |
| `cargo test` | 119 passed, 0 failed |
| `node --check` × 7 个注入脚本 | 全部通过 |
| `cargo fmt --check` | 44 处（main 是 52）——没跑过 fmt，减少的 8 处是被重写的代码碰巧变得合规 |

测试数 120 → 119 的账：ebab8b4 加了 2 个，091ae5c 删了 2 个加回 1 个。

**ebab8b4 是唯一改动了生成代码的 commit**，所以单独核对过：用 `git worktree` 在 base 上跑同一个 `dumps_the_scripts`，生成改动前的七个脚本再逐字节 diff。`notify.js` / `turn.js` / `waiting.js` 完全相同；另外四个只差被移走的注释、一个形参改名，以及 `'x'` 变成 `"x"`（class 现在和其他所有粘贴进去的字符串一样走 `{:?}`）。JS 语义零变化。

守门测试都还在过：`every_mode_this_module_runs_is_one_the_scripts_take`、`every_verb_the_panel_signals_is_one_the_app_answers`、两份 `ignores_the_field_in_another_section`、`reads_the_name_a_spec_installs_under` + `reads_the_package_a_refusal_blames`。

## 不在这个 PR 里

两个 `bash.exe.stackdump`（根目录和 `src-tauri/`）已从工作副本删除。它们只有裸地址、没有项目内容、且已在 `.gitignore` 里未被跟踪，所以没有产生 commit。
