### PR TITLE
fix: two ways a plugin change left dsh needing a reinstall

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3316,6 +3316,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,12 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
-serde_json = "1"
+# `preserve_order` because one thing here does not just read JSON but writes it
+# back: `plugins::forget_bundles` reparses the profile manifest, takes a name
+# out of one array and reserializes the whole file. Without the feature a
+# `Map` is a `BTreeMap`, so that round trip would alphabetise every key of a
+# file dsh owns and rewrites itself — a diff nobody asked for, on every repair.
+serde_json = { version = "1", features = ["preserve_order"] }
 # dsh versions carry prerelease tags (`0.1.0-rc.6`); comparing those by hand is
 # how you end up shipping rc.10 as older than rc.9.
 semver = "1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -801,7 +801,31 @@ fn update_dsh(app: &tauri::AppHandle) {
 /// Start `dsh web` and hand the window over to it. Blocks until it is serving or
 /// has given up, reporting either onto the loading page.
 fn start_serving(app: &tauri::AppHandle, window: &WebviewWindow, session: &Session) {
-    session.splash.status(window, t!("正在启动 dsh…", "Starting dsh…"));
+    // Before the spawn, because what it repairs is a `dsh web` that exits on
+    // the way up rather than one that misbehaves once it is serving: a name on
+    // the profile's layer stack that no longer resolves is a `throw` before the
+    // port is bound. See [`plugins::audit`] for how the profile gets into that
+    // state and why nothing in dsh gets it out again.
+    //
+    // Said out loud when it does something. This rewrites a file the user owns,
+    // and the alternative to saying so is a launch that inexplicably worked
+    // after one that inexplicably did not. Folded into the line the start was
+    // going to draw anyway rather than shown first and overwritten a moment
+    // later, which is a message nobody can read.
+    let cleared = plugins::audit(app);
+
+    session.splash.status(
+        window,
+        &if cleared.is_empty() {
+            t!("正在启动 dsh…", "Starting dsh…").to_string()
+        } else {
+            t!(
+                "清掉了上次装卸插件没收尾留下的残留（{}），正在启动 dsh…",
+                "Cleared what an unfinished plugin change left behind ({}); starting dsh…",
+                cleared.join(" ")
+            )
+        },
+    );
     session.splash.progress(window, -1.0);
 
     match server::start(app, None) {
@@ -970,6 +994,14 @@ fn resume(window: &WebviewWindow, session: &Session) -> Result<Receiver<server::
         app,
         t!("dsh 已断开，正在重新启动…", "dsh disconnected; restarting it…"),
     );
+
+    // A dsh that exited on its own may have exited because the profile's layer
+    // stack names something it can no longer resolve — an install or removal
+    // that pnpm did not finish is exactly the kind of thing that stops a server
+    // mid-run. Cheap, and the alternative is restarting into the same refusal
+    // [`RESTARTS`] times over. Its own line goes to the terminal; there is
+    // nothing on screen here but dsh's own connection indicator.
+    plugins::audit(app);
 
     let was = served_port(&session.origin);
     let mut outcome = attempt(window, session, was);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,7 @@ mod setup;
 mod signal;
 mod theme;
 mod toast;
+mod transport;
 mod update;
 
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
@@ -260,6 +261,11 @@ fn build_window(
             "window.__DSH_VERSION__ = {:?};",
             env!("CARGO_PKG_VERSION")
         ))
+        // One reload for a page holding a plugin-bundle address the server has
+        // moved on from — which is what installing or removing a plugin does to
+        // every document loaded before it. See [`transport`], which is mostly an
+        // explanation of why the failure is otherwise permanent.
+        .initialization_script(transport::script())
         .on_page_load(move |webview, payload| {
             // The first page this window ever loads is the bundled loading page,
             // and this is the one place its address is stated by something that

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -63,6 +63,9 @@ fn labels() -> String {
         // On the card, at the end of its name: what used to be a heading
         // over a list of its own. Both halves are one list now.
         "have": t!("已安装", "Installed"),
+        // The third thing a card can be, and the one nobody wants to see: a
+        // name dsh still loads that nothing installed. See `plugins::holdings`.
+        "residue": t!("残留", "Residue"),
         // The group headings. `recommended` and `authored` are the two the
         // shipped list uses; `other` catches a section name the list invents
         // that this panel has no heading for. See `section` in plugins.rs.
@@ -321,8 +324,11 @@ pub fn script() -> String {
     var name = make('div', 'dsh-pp-name', body);
     name.appendChild(document.createTextNode(item.name));
     if (item.fix) name.appendChild(chip('fix', TEXT.fix));
-    // Last on the line, after any chip a preset came with.
-    if (item.installed) name.appendChild(chip('installed', TEXT.have));
+    // Last on the line, after any chip a preset came with. Residue instead of
+    // "installed", never both: the tick does the same thing to either, but
+    // calling a leftover an installed plugin is the thing that hid it.
+    if (item.stale) name.appendChild(chip('stale', TEXT.residue));
+    else if (item.installed) name.appendChild(chip('installed', TEXT.have));
 
     // What is actually going on the machine, where the name does not already
     // say it. The names are translated, so `插件市场` on its own names nothing
@@ -443,7 +449,8 @@ pub fn script() -> String {
         description: item.description,
         url: item.url,
         section: item.section,
-        installed: true
+        installed: true,
+        stale: !!item.stale
       }};
     }}));
 
@@ -616,6 +623,9 @@ pub fn script() -> String {
       'border-radius:999px;border:1px solid currentColor}}' +
       '.dsh-pp-chip.dsh-pp-fix{{color:var(--pp-fix)}}' +
       '.dsh-pp-chip.dsh-pp-installed{{color:var(--pp-ok)}}' +
+      // The same red the removal button wears, because it is the same verb:
+      // this one is here to be taken away.
+      '.dsh-pp-chip.dsh-pp-stale{{color:var(--pp-danger)}}' +
       '.dsh-pp-hint{{display:block;margin-top:12px;font-size:12px;color:var(--pp-muted)}}' +
       '.dsh-pp-spec{{width:100%;margin-top:4px;padding:8px 11px;' +
       'border:1px solid var(--pp-line);border-radius:8px;background:var(--pp-bg);' +

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -473,9 +473,9 @@ pub fn listing(app: &AppHandle) -> String {
     // keeps the description, the repository and the section it had while it
     // was still something to install. A plugin the shipped list has never
     // heard of has none of the three, and gets the card that is left.
-    let held: Vec<serde_json::Value> = dependencies_in(&manifest)
+    let held: Vec<serde_json::Value> = holdings(&manifest)
         .into_iter()
-        .map(|(name, version)| {
+        .map(|(name, version, stale)| {
             let preset = presets.iter().find(|preset| preset.package == name);
             let label = preset
                 .map(|preset| preset.name.clone())
@@ -484,9 +484,28 @@ pub fn listing(app: &AppHandle) -> String {
                 "name": name,
                 "label": label,
                 "version": version,
-                "description": preset.map(|preset| preset.description.as_str()),
+                // What residue is, in place of whatever the shipped list says
+                // the package does. A card reading "插件市场" with a red chip on
+                // it and the description it has always had explains nothing;
+                // the fact worth having is why it is on the list twice.
+                "description": if stale {
+                    t!(
+                        "这一条还挂在 profile 的层列表上，但它已经不是依赖了 —— \
+                         上次装或卸插件没收尾留下的。勾上卸载就能清掉，不会动到别的插件。",
+                        "This is still on the profile's layer stack but is no longer a \
+                         dependency — residue from a plugin change that did not finish. \
+                         Tick it and remove to clear it; nothing else is touched."
+                    )
+                    .to_string()
+                } else {
+                    preset.map(|preset| preset.description.clone()).unwrap_or_default()
+                },
                 "url": preset.map(|preset| preset.url.as_str()),
                 "section": preset.map(|preset| preset.section.as_str()),
+                // Drawn with a chip of its own, and worth the extra field: a
+                // card the user is told is residue reads differently from one
+                // that says a plugin is working.
+                "stale": stale,
             })
         })
         .collect();
@@ -516,11 +535,8 @@ fn profile_manifest(app: &AppHandle) -> serde_json::Value {
 /// `dsh.profile.bundles` is deliberately not read here, though [`installed_in`]
 /// reads both: `@deepseek-ai/dsh-base` and `@deepseek-ai/dsh-web-app` are on
 /// that list and are not plugins. Offering to remove the profile's own
-/// foundation would be offering to break it.
-fn dependencies(app: &AppHandle) -> Vec<(String, String)> {
-    dependencies_in(&profile_manifest(app))
-}
-
+/// foundation would be offering to break it — which is what [`holdings`],
+/// which does read both, has [`FOUNDATION`] for.
 fn dependencies_in(manifest: &serde_json::Value) -> Vec<(String, String)> {
     manifest
         .get("dependencies")
@@ -533,6 +549,40 @@ fn dependencies_in(manifest: &serde_json::Value) -> Vec<(String, String)> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Everything the panel may offer to take out, with the range pnpm recorded and
+/// whether the entry is residue rather than a plugin.
+///
+/// `dependencies` is what pnpm installed and the whole of what `dsh plugin
+/// remove` can act on. The layer stack carries a second, smaller set: a name
+/// dsh still loads on every boot that is no longer a dependency at all. That
+/// state is reachable — see [`audit`] for the line in dsh that leaves it — and
+/// reading `dependencies` alone made it invisible here and unremovable in
+/// [`remove`], while [`installed_in`] went on counting it as installed and so
+/// kept the matching preset off the offered half too. A plugin that is in the
+/// profile twice over and listed nowhere is the shape of a user reinstalling
+/// the app, which is what this is for.
+///
+/// The residue half carries no range because there is no dependency to have
+/// recorded one.
+fn holdings(manifest: &serde_json::Value) -> Vec<(String, String, bool)> {
+    let mut held: Vec<(String, String, bool)> = dependencies_in(manifest)
+        .into_iter()
+        .map(|(name, range)| (name, range, false))
+        .collect();
+
+    for name in bundles_in(manifest) {
+        if FOUNDATION.contains(&name.as_str()) {
+            continue;
+        }
+        if held.iter().any(|(held, _, _)| held == &name) {
+            continue;
+        }
+        held.push((name, String::new(), true));
+    }
+
+    held
 }
 
 /// What the profile manifest says is in it.
@@ -548,17 +598,174 @@ fn installed_in(manifest: &serde_json::Value) -> HashSet<String> {
         .map(|deps| deps.keys().cloned().collect::<Vec<_>>())
         .unwrap_or_default();
 
-    let bundles = manifest
+    dependencies.into_iter().chain(bundles_in(manifest)).collect()
+}
+
+/// The layer stack, in the order dsh composes it.
+fn bundles_in(manifest: &serde_json::Value) -> Vec<String> {
+    manifest
         .pointer("/dsh/profile/bundles")
         .and_then(serde_json::Value::as_array)
         .map(|list| {
             list.iter()
                 .filter_map(|name| name.as_str().map(str::to_string))
-                .collect::<Vec<_>>()
+                .collect()
         })
-        .unwrap_or_default();
+        .unwrap_or_default()
+}
 
-    dependencies.into_iter().chain(bundles).collect()
+/// The names a fresh `web` profile is born with on the layer stack without ever
+/// having been dependencies.
+///
+/// dsh's own reconcile protects these by never taking out a name that has not
+/// been a dependency — it has the manifest as it was before pnpm ran, so it can
+/// tell an in-box bundle from one a user installed. [`audit`] has only the
+/// manifest as it stands, so the same protection has to be written down. It is
+/// the second of two guards and not the only one: a name has to be missing from
+/// `dependencies` *and* have nothing under the profile's `node_modules` before
+/// anything touches it, so a future dsh that ships another in-box bundle costs
+/// this list an entry rather than costing the user their profile.
+const FOUNDATION: [&str; 2] = ["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app"];
+
+/// Take out of `dsh.profile.bundles` every name the profile can no longer load,
+/// and answer with what went.
+///
+/// This exists because of one line in dsh's plugin command:
+///
+/// ```js
+/// if (exitCode === 0) reconcilePlugins(before, dir);
+/// ```
+///
+/// pnpm writes `package.json` before it has finished rewriting `node_modules`,
+/// and dsh reconciles the layer stack against the manifest only when pnpm came
+/// back clean. So a removal that pnpm starts and then fails — on Windows most
+/// often the `EPERM` a dangling junction answers with, which [`repair`] is the
+/// other half of, or a `minimumReleaseAge` refusal — can leave the dependency
+/// gone from `dependencies` and its name still on the layer stack. Nothing in
+/// dsh ever reconciles that state again, because the reconcile it needs is the
+/// one that was skipped.
+///
+/// What it costs is the whole app: `dsh web` resolves every bundle on the stack
+/// before it binds a port, and a name it cannot resolve is a `throw` rather than
+/// a warning — so dsh does not start at all, and this app's panel could neither
+/// show the name nor remove it (see [`listing`] and [`remove`], which used to
+/// read `dependencies` alone). The way out was reinstalling.
+///
+/// Best effort and loud: a manifest that will not parse, or a write that fails,
+/// leaves the profile exactly as it was and says so on the terminal. Answering
+/// with the names rather than a bool because the caller puts them on screen —
+/// a repair nobody is told about is indistinguishable from a dsh that
+/// inexplicably started this time.
+pub fn audit(app: &AppHandle) -> Vec<String> {
+    let stale = stale_bundles(
+        &profile_manifest(app),
+        &profile_dir(app).join("node_modules"),
+    );
+
+    if stale.is_empty() {
+        return Vec::new();
+    }
+
+    match forget_bundles(app, &stale) {
+        Ok(()) => {
+            // Here rather than at each call site: two of the three reach this
+            // from a path with no status line to draw on, and a repair of the
+            // user's profile is worth a line in the terminal wherever it
+            // happened.
+            eprintln!(
+                "dsh-desktop: took {} off the profile's layer stack — nothing installs them",
+                stale.join(" ")
+            );
+            stale
+        }
+        Err(why) => {
+            eprintln!(
+                "dsh-desktop: could not take {} off the layer stack: {why}",
+                stale.join(" ")
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// The names on the layer stack that nothing in the profile can load.
+///
+/// Both guards, in order: [`FOUNDATION`], then `dependencies`, then whether the
+/// package is actually under `modules`. All three have to say no. Split out of
+/// [`audit`] so the rule can be read — and tested — without an app handle, since
+/// what it decides is which entries get deleted out of a file the user owns.
+fn stale_bundles(manifest: &serde_json::Value, modules: &Path) -> Vec<String> {
+    let held: HashSet<String> = dependencies_in(manifest)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+
+    bundles_in(manifest)
+        .into_iter()
+        .filter(|name| !FOUNDATION.contains(&name.as_str()))
+        .filter(|name| !held.contains(name))
+        // A scoped name carries its own separator, which `join` takes on every
+        // platform this builds for.
+        .filter(|name| !modules.join(name).join("package.json").is_file())
+        .collect()
+}
+
+/// Rewrite the profile manifest without `names` on its layer stack.
+///
+/// Through a sibling and a rename, the way [`stage_bundled`] writes: the file
+/// being replaced is the one thing standing between the user and a dsh that
+/// starts, and a half-written one is worse than the state being repaired.
+///
+/// Only `dsh.profile.bundles` is touched. `dependencies` is pnpm's, and a name
+/// that is still listed there is not this function's business — [`audit`] has
+/// already established that these are not.
+fn forget_bundles(app: &AppHandle, names: &[String]) -> Result<(), String> {
+    let path = profile_dir(app).join("package.json");
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|error| format!("could not read {}: {error}", path.display()))?;
+    let text = without_bundles(&raw, names).map_err(|why| format!("{}: {why}", path.display()))?;
+
+    let tmp = path.with_extension("json.new");
+    std::fs::write(&tmp, text.as_bytes())
+        .map_err(|error| format!("could not write {}: {error}", tmp.display()))?;
+    std::fs::rename(&tmp, &path).map_err(|error| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("could not move {} into place: {error}", tmp.display())
+    })
+}
+
+/// One profile manifest, as text, without `names` on its layer stack.
+///
+/// The whole of what a repair changes, so that the change can be read against
+/// a file rather than inferred from one. Only `dsh.profile.bundles` is touched:
+/// `dependencies` is pnpm's, and a name still listed there is not this
+/// function's business — [`audit`] has already established that these are not.
+///
+/// dsh writes this file as `JSON.stringify(manifest, undefined, 2) + "\n"`, and
+/// this matches it down to the trailing newline, so a repair does not also
+/// reformat the file under dsh. Key order survives because `serde_json` is
+/// built here with `preserve_order`; see `Cargo.toml`, where that is the only
+/// reason the feature is on.
+fn without_bundles(raw: &str, names: &[String]) -> Result<String, String> {
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(raw).map_err(|error| format!("could not parse it: {error}"))?;
+
+    if let Some(list) = manifest
+        .pointer_mut("/dsh/profile/bundles")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        list.retain(|entry| match entry.as_str() {
+            Some(name) => !names.iter().any(|gone| gone == name),
+            // Not a string, so not a name anything here put there and not one
+            // `audit` could have chosen. Left exactly as found.
+            None => true,
+        });
+    }
+
+    let mut text = serde_json::to_string_pretty(&manifest)
+        .map_err(|error| format!("could not serialize it: {error}"))?;
+    text.push('\n');
+    Ok(text)
 }
 
 /// The plugin that tells this app what dsh is doing, by the name it installs
@@ -1727,27 +1934,59 @@ fn commas(value: &str) -> Vec<String> {
 /// No `-w` here. pnpm's refusal to touch a workspace root without one is
 /// `add`'s alone — `remove` at the same root is not questioned.
 pub fn remove(app: &AppHandle, names: &[String], log: &Log) -> Result<(), String> {
-    let held: Vec<String> = dependencies(app)
-        .into_iter()
-        .map(|(name, _)| name)
-        .collect();
+    // Only what the manifest actually lists, and split the way the manifest
+    // lists it. The panel builds its cards out of the same two halves, so a
+    // name on neither did not come from the panel — and `dsh plugin remove` is
+    // not the place to find out what else it would have done with it.
+    let holdings = holdings(&profile_manifest(app));
+    let wanted = |residue: bool| -> Vec<String> {
+        holdings
+            .iter()
+            .filter(|(_, _, stale)| *stale == residue)
+            .filter(|(held, _, _)| names.iter().any(|name| name == held))
+            .map(|(held, _, _)| held.clone())
+            .collect()
+    };
 
-    // Only what the manifest actually lists. The panel builds its list out of
-    // that same manifest, so a name that is not on it did not come from the
-    // panel — and `dsh plugin remove` is not the place to find out what else it
-    // would have done with it.
-    let names: Vec<&str> = names
-        .iter()
-        .filter(|name| held.iter().any(|held| held == *name))
-        .map(String::as_str)
-        .collect();
+    let stale = wanted(true);
+    let names = wanted(false);
 
-    if names.is_empty() {
+    if names.is_empty() && stale.is_empty() {
         return Err(t!(
             "选中的插件不在这个 profile 里，没有可卸载的。",
             "nothing selected is installed in this profile."
         )
         .to_string());
+    }
+
+    // Residue first, and without pnpm anywhere near it. There is no dependency
+    // for pnpm to take out, so `dsh plugin remove` would hand it a name it does
+    // not hold, come back non-zero, and — this being the whole of how the state
+    // arose — skip the reconcile that would have cleared the layer stack. See
+    // [`audit`]. What is left behind is the package directory, which pnpm prunes
+    // on its next successful run and which dsh stops loading the moment its name
+    // is off the stack.
+    if !stale.is_empty() {
+        log(&t!(
+            "正在从 profile 的层列表里摘掉残留：{}",
+            "Taking residue off the profile's layer stack: {}",
+            stale.join(" ")
+        ));
+        forget_bundles(app, &stale).map_err(|why| {
+            t!(
+                "无法改写 profile 清单：{}",
+                "the profile manifest could not be rewritten: {}",
+                why
+            )
+        })?;
+    }
+
+    // Nothing pnpm has to be started for. Which is worth returning early over:
+    // everything below this waits on dsh, on pnpm, and on a `repair` walk of
+    // `node_modules`, for a removal that is already done.
+    if names.is_empty() {
+        log(t!("残留已清掉。", "The residue is gone."));
+        return Ok(());
     }
 
     let dsh = crate::dsh::current(app).ok_or_else(|| {
@@ -1851,8 +2090,9 @@ pub fn open_directory(app: &AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::{
-        dependencies_in, is_package_spec, local_spec, parse, pnpm_blamed, pnpm_codes, pnpm_stuck,
-        requested, spec_name, sweep, wanted_gone, Outcome, BUNDLED, PRESETS, RELEASE_AGE, SIGNAL,
+        dependencies_in, holdings, is_package_spec, local_spec, parse, pnpm_blamed, pnpm_codes,
+        pnpm_stuck, requested, spec_name, stale_bundles, sweep, wanted_gone, without_bundles,
+        Outcome, BUNDLED, FOUNDATION, PRESETS, RELEASE_AGE, SIGNAL,
     };
     use std::path::{Path, PathBuf};
     use tauri::Url;
@@ -2521,6 +2761,119 @@ mod tests {
                 String::from_utf8_lossy(&made.stderr)
             );
         }
+    }
+
+    /// The two halves the panel draws, told apart. A dependency is a plugin; a
+    /// name left on the layer stack without one is residue, and the profile's
+    /// own foundation is neither and must never be offered for removal.
+    #[test]
+    fn holdings_tells_a_plugin_from_what_is_left_on_the_stack() {
+        let manifest = serde_json::json!({
+            "dependencies": { "dshmarket": "^1.41.0" },
+            "dsh": { "profile": { "bundles": [
+                "@deepseek-ai/dsh-base",
+                "@deepseek-ai/dsh-web-app",
+                "dshmarket",
+                "dsh-antigravity",
+            ] } }
+        });
+
+        let held = holdings(&manifest);
+
+        assert_eq!(
+            held,
+            vec![
+                ("dshmarket".to_string(), "^1.41.0".to_string(), false),
+                ("dsh-antigravity".to_string(), String::new(), true),
+            ],
+        );
+        for name in FOUNDATION {
+            assert!(
+                !held.iter().any(|(held, _, _)| held == name),
+                "{name} is the profile's own foundation and is not removable"
+            );
+        }
+    }
+
+    /// What [`super::audit`] deletes out of the user's manifest, and the three
+    /// things that have to be true before it does. Each guard is given an entry
+    /// that only it rejects, so a guard quietly dropped fails this.
+    #[test]
+    fn stale_bundles_needs_every_guard_to_agree() {
+        let scratch = Scratch::new("stale-bundles");
+        let modules = scratch.dir("node_modules");
+        // Not a dependency, but installed — dsh resolves it, so it loads, and
+        // taking it off the stack would be this app removing a working plugin.
+        std::fs::write(
+            scratch.dir("node_modules/still-here").join("package.json"),
+            b"{\"name\":\"still-here\"}",
+        )
+        .expect("the installed package");
+
+        let manifest = serde_json::json!({
+            "dependencies": { "dshmarket": "^1.41.0" },
+            "dsh": { "profile": { "bundles": [
+                // Foundation: not a dependency and not under node_modules,
+                // and still not ours to touch.
+                "@deepseek-ai/dsh-base",
+                "@deepseek-ai/dsh-web-app",
+                // A dependency, so pnpm owns it.
+                "dshmarket",
+                "still-here",
+                // Nothing holds this one and nothing can load it.
+                "dsh-antigravity",
+            ] } }
+        });
+
+        assert_eq!(
+            stale_bundles(&manifest, &modules),
+            vec!["dsh-antigravity".to_string()]
+        );
+    }
+
+    /// The repair, against the file it repairs. Only the named entry goes, and
+    /// what comes back is byte-for-byte what dsh would have written — same key
+    /// order, same two-space indent, same trailing newline — so a repair does
+    /// not show up as a reformat the next time dsh writes the file.
+    #[test]
+    fn without_bundles_takes_one_line_and_leaves_the_file_alone() {
+        let before = concat!(
+            "{\n",
+            "  \"name\": \"dsh-profile-web\",\n",
+            "  \"private\": true,\n",
+            "  \"dependencies\": {\n",
+            "    \"dshmarket\": \"^1.41.0\"\n",
+            "  },\n",
+            "  \"dependenciesMeta\": {},\n",
+            "  \"dsh\": {\n",
+            "    \"profile\": {\n",
+            "      \"bundles\": [\n",
+            "        \"@deepseek-ai/dsh-base\",\n",
+            "        \"dshmarket\",\n",
+            "        \"dsh-antigravity\"\n",
+            "      ]\n",
+            "    }\n",
+            "  }\n",
+            "}\n",
+        );
+
+        let after = without_bundles(before, &["dsh-antigravity".to_string()]).expect("a rewrite");
+
+        assert_eq!(after, before.replace(",\n        \"dsh-antigravity\"", ""));
+    }
+
+    /// A manifest with no layer stack at all, and one that will not parse. The
+    /// first is a profile dsh has not written yet and is not an error; the
+    /// second must not be overwritten with a guess at what it meant.
+    #[test]
+    fn without_bundles_leaves_what_it_does_not_understand() {
+        let plain = "{\n  \"name\": \"dsh-profile-web\"\n}\n";
+        assert_eq!(
+            without_bundles(plain, &["anything".to_string()]).expect("a rewrite"),
+            plain
+        );
+
+        assert!(without_bundles("{ not json", &[]).is_err());
     }
 
     /// A directory of this test's own, gone again when it ends. Built on disk,

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -536,7 +536,7 @@ fn profile_manifest(app: &AppHandle) -> serde_json::Value {
 /// reads both: `@deepseek-ai/dsh-base` and `@deepseek-ai/dsh-web-app` are on
 /// that list and are not plugins. Offering to remove the profile's own
 /// foundation would be offering to break it — which is what [`holdings`],
-/// which does read both, has [`FOUNDATION`] for.
+/// which does read both, has [`IN_BOX`] for.
 fn dependencies_in(manifest: &serde_json::Value) -> Vec<(String, String)> {
     manifest
         .get("dependencies")
@@ -573,7 +573,7 @@ fn holdings(manifest: &serde_json::Value) -> Vec<(String, String, bool)> {
         .collect();
 
     for name in bundles_in(manifest) {
-        if FOUNDATION.contains(&name.as_str()) {
+        if name.starts_with(IN_BOX) {
             continue;
         }
         if held.iter().any(|(held, _, _)| held == &name) {
@@ -614,18 +614,35 @@ fn bundles_in(manifest: &serde_json::Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// The names a fresh `web` profile is born with on the layer stack without ever
-/// having been dependencies.
+/// The scope dsh's own in-box bundles are named in.
 ///
-/// dsh's own reconcile protects these by never taking out a name that has not
-/// been a dependency — it has the manifest as it was before pnpm ran, so it can
-/// tell an in-box bundle from one a user installed. [`audit`] has only the
-/// manifest as it stands, so the same protection has to be written down. It is
-/// the second of two guards and not the only one: a name has to be missing from
-/// `dependencies` *and* have nothing under the profile's `node_modules` before
-/// anything touches it, so a future dsh that ships another in-box bundle costs
-/// this list an entry rather than costing the user their profile.
-const FOUNDATION: [&str; 2] = ["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app"];
+/// A profile's layer stack is born with names that were never dependencies —
+/// `@deepseek-ai/dsh-base` and `@deepseek-ai/dsh-web-app` for the `web`
+/// template dsh ships today. dsh's own reconcile protects them by never taking
+/// out a name that has not been a dependency: it has the manifest as it was
+/// before pnpm ran, so it can tell an in-box bundle from one a user installed.
+/// [`audit`] has only the manifest as it stands, so the same protection has to
+/// be written down here.
+///
+/// Written as the scope rather than as a copy of that pair, because the pair is
+/// not a constant this app can hold. dsh's `PROFILE_TEMPLATES` is what a
+/// profile is born from and dsh normalizes an existing profile's tuple to it
+/// across its own versions, so a dsh update is free to put a third in-box name
+/// on a stack this app is about to read.
+///
+/// And the other two guards would not catch that name. It is not a dependency,
+/// and it is not under the profile's `node_modules` either: dsh's
+/// `resolveBundleDir` tries the dsh installation's anchor first and the
+/// profile's second, so every in-box bundle resolves out of dsh's own tree —
+/// which is exactly where this scope is, and where nothing pnpm installs into a
+/// profile on a user's behalf ever is.
+///
+/// What it costs is residue whose package happens to be in this scope, which
+/// [`audit`] leaves alone rather than guess about. That is a repair not done,
+/// on a state that is already rare; the other way round is this app deleting a
+/// layer the user's dsh needs, on every launch, over a dsh update it has never
+/// heard of.
+const IN_BOX: &str = "@deepseek-ai/";
 
 /// Take out of `dsh.profile.bundles` every name the profile can no longer load,
 /// and answer with what went.
@@ -690,7 +707,7 @@ pub fn audit(app: &AppHandle) -> Vec<String> {
 
 /// The names on the layer stack that nothing in the profile can load.
 ///
-/// Both guards, in order: [`FOUNDATION`], then `dependencies`, then whether the
+/// All three guards, in order: [`IN_BOX`], then `dependencies`, then whether the
 /// package is actually under `modules`. All three have to say no. Split out of
 /// [`audit`] so the rule can be read — and tested — without an app handle, since
 /// what it decides is which entries get deleted out of a file the user owns.
@@ -702,7 +719,7 @@ fn stale_bundles(manifest: &serde_json::Value, modules: &Path) -> Vec<String> {
 
     bundles_in(manifest)
         .into_iter()
-        .filter(|name| !FOUNDATION.contains(&name.as_str()))
+        .filter(|name| !name.starts_with(IN_BOX))
         .filter(|name| !held.contains(name))
         // A scoped name carries its own separator, which `join` takes on every
         // platform this builds for.
@@ -2092,7 +2109,7 @@ mod tests {
     use super::{
         dependencies_in, holdings, is_package_spec, local_spec, parse, pnpm_blamed, pnpm_codes,
         pnpm_stuck, requested, spec_name, stale_bundles, sweep, wanted_gone, without_bundles,
-        Outcome, BUNDLED, FOUNDATION, PRESETS, RELEASE_AGE, SIGNAL,
+        Outcome, BUNDLED, IN_BOX, PRESETS, RELEASE_AGE, SIGNAL,
     };
     use std::path::{Path, PathBuf};
     use tauri::Url;
@@ -2787,10 +2804,10 @@ mod tests {
                 ("dsh-antigravity".to_string(), String::new(), true),
             ],
         );
-        for name in FOUNDATION {
+        for (name, _, _) in &held {
             assert!(
-                !held.iter().any(|(held, _, _)| held == name),
-                "{name} is the profile's own foundation and is not removable"
+                !name.starts_with(IN_BOX),
+                "{name} is dsh's own and is not this panel's to offer"
             );
         }
     }
@@ -2813,10 +2830,13 @@ mod tests {
         let manifest = serde_json::json!({
             "dependencies": { "dshmarket": "^1.41.0" },
             "dsh": { "profile": { "bundles": [
-                // Foundation: not a dependency and not under node_modules,
-                // and still not ours to touch.
+                // In-box: not dependencies and not under this node_modules,
+                // because dsh resolves them out of its own installation. The
+                // third is the one no list of names would have had in it — a
+                // bundle a later dsh puts on the stack by itself.
                 "@deepseek-ai/dsh-base",
                 "@deepseek-ai/dsh-web-app",
+                "@deepseek-ai/dsh-not-shipped-yet",
                 // A dependency, so pnpm owns it.
                 "dshmarket",
                 "still-here",

--- a/src-tauri/src/transport.rs
+++ b/src-tauri/src/transport.rs
@@ -1,0 +1,177 @@
+//! One reload, when the page cannot fetch the script its own boot manifest
+//! told it to fetch.
+//!
+//! dsh serves every plugin's browser half as *one* combined script — a combo
+//! URL naming all of them at once, `/plugins/??a/client.js,b/client.js,…&rev=`,
+//! whose `rev` is a content hash over the bytes of every bundle in it. The
+//! address is minted when `index.html` is rendered, inlined into the page as
+//! `window.__DSH_BOOT__`, and answered by an exact-match table that keeps the
+//! current composition and one generation before it. Everything else is a 404.
+//!
+//! So the page and the server can disagree, and the way they come to disagree
+//! is installing or removing a plugin: that changes which bundles are in the
+//! batch and therefore the hash naming it. A document holding an address from
+//! before the change asks for a script that no longer exists — and because the
+//! batch is all of them, the one 404 takes dsh's own interface down with the
+//! plugin that was added or removed. What the user gets is a card reading
+//! "Failed to load plugins" over a list of forty-odd packages they never
+//! installed.
+//!
+//! It does not recover on its own, and that is the part worth fixing. dsh's
+//! boot card has no retry. This app deliberately does not reload the page when
+//! `dsh web` comes back on the port it was on — see [`crate::resume`], where
+//! staying put is how a draft in the composer survives a restart — which is
+//! right for a page that booted and wrong for one that never did. Between them
+//! the window sits on a dead page for as long as the user leaves it there.
+//!
+//! ## The seam
+//!
+//! dsh's web boot reads an optional `globalThis.__DSH_TRANSPORT__`, and takes
+//! `loadBundle` off it in place of its own script-tag loader. This installs one
+//! that does exactly what the default does and, when a fetch fails, reloads the
+//! document instead of rejecting: the reload re-renders `index.html`, which
+//! mints the addresses again from the composition the server actually has.
+//!
+//! Two things it deliberately does not cover. The bootstrap batch is a plain
+//! `<script src>` in the served markup rather than something `loadBundle` is
+//! asked for, so a 404 there is still dsh's card — but that batch is one
+//! package, `@deepseek-ai/dsh-client-modules`, and its address moves only when
+//! dsh itself is updated. And a server that is actually down fails the retry
+//! too, which is what [`BUDGET`] is for: a stale address costs one reload, and
+//! a dsh that is gone stops reloading and lets dsh say so.
+
+/// How many reloads one document may spend, and how long apart.
+///
+/// The recovery this is for costs exactly one: the reload re-reads the manifest
+/// and the second attempt is against addresses that exist. More than one is
+/// therefore not this failure, and the budget stops a broken server turning the
+/// window into a reload loop. It is not one, because a window is long-lived —
+/// `sessionStorage` outlives a reload and is only cleared when the window is —
+/// and a user who changes plugins twice in an afternoon should get the repair
+/// both times.
+const BUDGET: u32 = 3;
+
+/// Seconds between reloads, so a failure that answers instantly cannot spend
+/// the whole budget before the user sees anything.
+const APART: u32 = 10;
+
+/// The script, for the window's `initialization_script`.
+///
+/// Runs at document start on every page this window loads, ours included, where
+/// it does nothing: the global is read by dsh's boot and by nothing else.
+///
+/// Guarded against replacing a transport that is already there. Nothing sets
+/// one today — the seam exists for an embedder, which is what this app is — but
+/// silently taking it over would be this app deciding it is the only embedder
+/// for a page it does not own.
+pub fn script() -> String {
+    format!(
+        r#"(function () {{
+  if (window.__DSH_TRANSPORT__) return;
+
+  var KEY = 'dsh-desktop:bundle-reload';
+
+  // Whether this document may spend a reload. `sessionStorage` throws in
+  // enough situations to be worth not trusting; a window that cannot keep
+  // the count gets one reload rather than none, since the failure this
+  // recovers from is the common one and a loop needs a broken server.
+  function mayReload() {{
+    var now = Date.now();
+    try {{
+      var seen = JSON.parse(sessionStorage.getItem(KEY) || '{{"n":0,"at":0}}');
+      if (seen.n >= {budget}) return false;
+      if (now - seen.at < {apart} * 1000) return false;
+      sessionStorage.setItem(KEY, JSON.stringify({{ n: seen.n + 1, at: now }}));
+      return true;
+    }} catch (e) {{
+      return true;
+    }}
+  }}
+
+  // What dsh's own loader does, kept the same on the way in: an async classic
+  // script, removed once it has run, resolving on load. A bundle registers its
+  // factory as a side effect of executing, so nothing is read off the element.
+  function fetchBundle(url) {{
+    return new Promise(function (resolve, reject) {{
+      var el = document.createElement('script');
+      el.async = true;
+      el.src = url;
+      el.addEventListener('load', function () {{ el.remove(); resolve(); }}, {{ once: true }});
+      el.addEventListener('error', function () {{
+        el.remove();
+        reject(new Error('dsh-desktop: bundle script ' + url + ' failed to load'));
+      }}, {{ once: true }});
+      document.head.append(el);
+    }});
+  }}
+
+  window.__DSH_TRANSPORT__ = {{
+    loadBundle: function (url) {{
+      return fetchBundle(url).catch(function (error) {{
+        if (!mayReload()) throw error;
+        // The document is going away, so this promise is never settled: dsh is
+        // mid-boot and resolving it would have it carry on against a page that
+        // is being replaced. The reload re-renders the manifest.
+        location.reload();
+        return new Promise(function () {{}});
+      }});
+    }}
+  }};
+}})();"#,
+        budget = BUDGET,
+        apart = APART,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{script, APART, BUDGET};
+
+    /// The two numbers are the whole of the loop protection, and they are
+    /// written into the script by `format!` rather than read from it. A
+    /// placeholder that stopped being substituted would leave a script that
+    /// parses and never stops reloading.
+    #[test]
+    fn the_budget_reaches_the_script() {
+        let script = script();
+        assert!(
+            script.contains(&format!("seen.n >= {BUDGET}")),
+            "the reload budget must be substituted: {script}"
+        );
+        assert!(
+            script.contains(&format!("< {APART} * 1000")),
+            "the interval must be substituted: {script}"
+        );
+    }
+
+    /// Every brace in the script body is doubled for `format!`, and one that is
+    /// not is a syntax error this app would ship without noticing: the script
+    /// is evaluated by the webview, not by the compiler. Balance is the cheapest
+    /// check that catches an unescaped `{` having eaten the rest of a line.
+    #[test]
+    fn the_script_is_balanced() {
+        let script = script();
+        let mut depth = 0i32;
+        for character in script.chars() {
+            match character {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            }
+            assert!(depth >= 0, "a closing brace with nothing open: {script}");
+        }
+        assert_eq!(depth, 0, "unbalanced braces: {script}");
+    }
+
+    /// The seam is dsh's, spelled its way. A typo here is a transport nothing
+    /// ever reads and a recovery that silently does not happen.
+    #[test]
+    fn it_installs_on_the_seam_dsh_reads() {
+        let script = script();
+        assert!(script.contains("window.__DSH_TRANSPORT__ = {"));
+        assert!(
+            script.contains("if (window.__DSH_TRANSPORT__) return;"),
+            "a transport already installed is left alone: {script}"
+        );
+    }
+}


### PR DESCRIPTION
Both of these came out of one report: a plugin installed from
`github:`, found not to work, removed again — and the next launch of dsh
answered

```
Failed to load plugins
  failed to import loader entry d5298d73 (@deepseek-ai/dsh-client-hmr):
  client-modules: bundle script /plugins/??@deepseek-ai/dsh-api-gateway/client.js,… failed to load
```

on one machine and nothing at all on another, from the same steps and
the same app version. The way out taken was reinstalling the app.

Two separate failures turned out to be able to end there. Neither is the
plugin's doing — the list of forty-odd packages in that error is dsh's
own interface, which rides in the same request.

## 1. A layer stack that outlived the plugin on it

`dsh plugin` reconciles `dsh.profile.bundles` only when pnpm exits 0,
and pnpm writes `package.json` before it finishes with `node_modules`.
A removal that fails in between — on Windows the `EPERM` a dangling
junction answers with, or a `minimumReleaseAge` refusal — leaves the
name off `dependencies` and still on the stack, and nothing reconciles
it afterwards.

`dsh web` then `throw`s before binding a port, so dsh does not start at
all; and the panel read `dependencies` alone, so it could neither show
the name nor remove it. Reproduced verbatim against a real profile.

`plugins::audit` clears it before the spawn, behind three guards. The
panel learns to draw the other half of the same state — a name still on
the stack whose package is still installed, which boots fine but was
invisible and unremovable — as a 残留 card, and `remove` takes those off
the manifest without going near pnpm.

## 2. A page holding an address the server has moved past

Every plugin's browser half is served as **one** combined script whose
`rev` is a content hash over all of them, and the bundle route answers
only the current composition and one generation back. Installing or
removing a plugin changes that hash, so a document from before the
change asks for a script that is now a 404 — and since the batch is all
of them, dsh's own UI goes down with it. It never recovers: the boot
card has no retry, and `resume` deliberately keeps the page across a
same-port restart.

`transport::script` installs a `loadBundle` on `globalThis.__DSH_TRANSPORT__`,
the seam dsh's boot already reads, which reloads the document instead of
rejecting. Budgeted at three, so a server that is actually down still
ends at dsh's own message rather than in a reload loop.

## Checked

`cargo test` — 148, of which 7 are new. Unit tests cover the three
guards, both halves of `holdings`, the manifest rewrite byte for byte,
and the injected script's braces and seam spelling; the transport was
run under stubs for all three outcomes.

The rest was driven in `tauri dev` against the real `~/.dsh/profiles/web`
over a WebView2 debugging port, since the panel's verbs are
`dsh-window://` navigations:

- a stack entry for an uninstalled plugin stops dsh dead before this and
  is repaired on launch after it, the manifest coming back
  `diff`-identical to the healthy original;
- `github:LiZhenNet/dsh-antigravity` installed and removed for real
  through the panel (application batch 56 rows → 57 → 56, no failure
  card either way);
- loadable residue drawn as `免费网络搜索 残留 <dsh-web-search-free>` and
  removed in 2.1s with no pnpm output;
- the transport handed an address the server really 404s, after which
  the document is replaced, the app re-mounts, and one of the three
  reloads shows spent.

The profile was restored from backup afterwards and re-verified against
its lockfile and `node_modules`.

## Note on `preserve_order`

`serde_json` gains that feature because `forget_bundles` reserializes a
file dsh owns. Without it a `Map` is a `BTreeMap` and every repair would
also alphabetise the manifest.
